### PR TITLE
Lock the version of Rust to a known working version.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable-2025-05-15"


### PR DESCRIPTION
The rust-toolchain file makes sure that Rust always tries to compile using this specific version, barring any overrides.

Doing this assures that the project will always correctly compile without issues as we know that this is a known working toolchain version.